### PR TITLE
Update Javalin to 6.1.3 and fix auth related bugs

### DIFF
--- a/server/build.sbt
+++ b/server/build.sbt
@@ -91,9 +91,9 @@ lazy val root = project
             "io.circe" %% "circe-parser" % circeVersion,
 
             // Javalin
-            "io.javalin" % "javalin" % "5.3.2",
-            "io.javalin" % "javalin-rendering" % "5.3.2",
-            "org.freemarker" % "freemarker" % "2.3.31",
+            "io.javalin" % "javalin" % "6.1.3",
+            "io.javalin" % "javalin-rendering" % "6.1.3",
+            "org.freemarker" % "freemarker" % "2.3.32",
             "javax.annotation" % "javax.annotation-api" % "1.3.2",
 
             // Uncategorized

--- a/server/src/main/scala/pulsar_auth/PulsarAuthInterceptor.scala
+++ b/server/src/main/scala/pulsar_auth/PulsarAuthInterceptor.scala
@@ -91,7 +91,7 @@ class PulsarAuthInterceptor extends ServerInterceptor:
                 .find(_.getName == "pulsar_auth")
                 .map(_.getValue)
 
-            parsePulsarAuthCookie(pulsarAuthCookie).getOrElse(defaultPulsarAuth)
+            pulsarAuthFromCookie(pulsarAuthCookie).getOrElse(defaultPulsarAuth)
         catch
             case e: Throwable =>
                 defaultPulsarAuth

--- a/server/src/main/scala/pulsar_auth/PulsarAuthServiceImpl.scala
+++ b/server/src/main/scala/pulsar_auth/PulsarAuthServiceImpl.scala
@@ -1,19 +1,13 @@
 package pulsar_auth
 
-import com.google.protobuf.ByteString
 import com.google.rpc.code.Code
 import com.google.rpc.status.Status
 import com.tools.teal.pulsar.ui.api.v1.pulsar_auth as pb
 import com.tools.teal.pulsar.ui.api.v1.pulsar_auth.{GetCurrentCredentialsRequest, GetCurrentCredentialsResponse, GetMaskedCredentialsRequest, GetMaskedCredentialsResponse}
 import com.typesafe.scalalogging.Logger
 import io.circe
-import io.circe.parser.decode as decodeJson
 
-import java.util.TimerTask
-import java.util.concurrent.*
-import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters.*
-import scala.jdk.OptionConverters.*
+import scala.concurrent.Future
 
 class PulsarAuthServiceImpl extends pb.PulsarAuthServiceGrpc.PulsarAuthService:
     val logger: Logger = Logger(getClass.getName)

--- a/ui/components/app/pulsar-auth/Editor/Editor.tsx
+++ b/ui/components/app/pulsar-auth/Editor/Editor.tsx
@@ -155,6 +155,8 @@ function credentialsTypeToLabel(type: MaskedCredentials['type']): string {
       return 'OAuth2';
     case 'jwt':
       return 'JWT';
+    case 'authParamsString':
+      return 'Auth Params String';
     default:
       return 'Unknown';
   }

--- a/ui/components/app/pulsar-auth/conversions.ts
+++ b/ui/components/app/pulsar-auth/conversions.ts
@@ -13,6 +13,9 @@ export function maskedCredentialsFromPb(credentialsPb: pb.MaskedCredentials): Ma
     case pb.CredentialsType.CREDENTIALS_TYPE_JWT:
       type = 'jwt';
       break;
+    case pb.CredentialsType.CREDENTIALS_TYPE_AUTH_PARAMS_STRING:
+      type = 'authParamsString';
+      break;
     default:
       throw new Error(`Unknown credentials type: ${credentialsPb.getType()}`);
   }


### PR DESCRIPTION
This PR updated the Javalin to newer 6.1.3 version and fixes bug ralated to auth cookie not being set by older version of Javaling by using `ctx.cookie(Cookie cookie)` method right away. 