### PR TITLE
Adding unload action on topic page

### DIFF
--- a/proto/proto/tools/teal/pulsar/ui/topic/v1/topic.proto
+++ b/proto/proto/tools/teal/pulsar/ui/topic/v1/topic.proto
@@ -135,6 +135,14 @@ message DeleteTopicResponse {
   google.rpc.Status status = 1;
 }
 
+message UnloadTopicRequest {
+  string topic_name = 1;
+}
+
+message UnloadTopicResponse {
+  google.rpc.Status status = 1;
+}
+
 // Stats
 
 enum ProducerAccessMode {
@@ -493,6 +501,7 @@ service TopicService {
   rpc ListTopics(ListTopicsRequest) returns (ListTopicsResponse);
   rpc ListPartitionedTopics(ListPartitionedTopicsRequest) returns (ListPartitionedTopicsResponse);
   rpc DeleteTopic(DeleteTopicRequest) returns (DeleteTopicResponse);
+  rpc UnloadTopic(UnloadTopicRequest) returns (UnloadTopicResponse);
   rpc GetTopicsProperties(GetTopicsPropertiesRequest) returns (GetTopicsPropertiesResponse);
   rpc SetTopicProperties(SetTopicPropertiesRequest) returns (SetTopicPropertiesResponse);
   rpc GetTopicsStats(GetTopicsStatsRequest) returns (GetTopicsStatsResponse);

--- a/server/src/main/scala/topic/TopicServiceImpl.scala
+++ b/server/src/main/scala/topic/TopicServiceImpl.scala
@@ -148,6 +148,18 @@ class TopicServiceImpl extends pb.TopicServiceGrpc.TopicService:
                             case Failure(err) => handleFailure(err)
                     case Failure(err) => handleFailure(err)
 
+    override def unloadTopic(request: pb.UnloadTopicRequest): Future[pb.UnloadTopicResponse] =
+        logger.info(s"Unloading topic: ${request.topicName}")
+        val adminClient = RequestContext.pulsarAdmin.get()
+
+        Try(adminClient.topics.unload(request.topicName)) match
+            case Success(_) =>
+                val status = Status(code = Code.OK.index)
+                Future.successful(pb.UnloadTopicResponse(status = Some(status)))
+            case Failure(err) =>
+                val status = Status(code = Code.FAILED_PRECONDITION.index, message = err.getMessage)
+                Future.successful(pb.UnloadTopicResponse(status = Some(status)))
+
     override def getTopicsStats(request: pb.GetTopicsStatsRequest): Future[pb.GetTopicsStatsResponse] =
         val adminClient = RequestContext.pulsarAdmin.get()
 

--- a/ui/components/TopicPage/Overview/Overview.tsx
+++ b/ui/components/TopicPage/Overview/Overview.tsx
@@ -27,6 +27,7 @@ import SkipMessagesModal from "../../SubscriptionPage/Overview/SkipMessages/Skip
 import ResetCursorModal from "../../SubscriptionPage/Overview/ResetCursor/ResetCursor";
 import ExpireAllSubscriptions from "../Subscriptions/ExpireAllMessages/ExpireAllSubscriptions";
 import * as Modals from "../../app/contexts/Modals/Modals";
+import UnloadTopicDialog from "../UnloadTopicDialog/UnloadTopicDialog";
 
 export type OverviewProps = {
   tenant: string;
@@ -183,6 +184,28 @@ const Overview: React.FC<OverviewProps> = (props) => {
                   title: `Expire Messages`,
                   content: (
                     <ExpireAllSubscriptions
+                      tenant={props.tenant}
+                      namespace={props.namespace}
+                      topic={props.topic}
+                      topicPersistency={props.topicPersistency}
+                    />
+                  ),
+                  styleMode: "no-content-padding",
+                })}
+              action={{type: 'predefined', action: 'without-icon'}}
+            />
+            <ActionButton
+              buttonProps={{
+                text: 'Unload Topic',
+              }}
+              title={'Unload Topic'}
+              testId={'topic-page-unload-button'}
+              onClick={() =>
+                modals.push({
+                  id: "unload-topic",
+                  title: `Unload Topic`,
+                  content: (
+                    <UnloadTopicDialog
                       tenant={props.tenant}
                       namespace={props.namespace}
                       topic={props.topic}

--- a/ui/components/TopicPage/TopicPage.tsx
+++ b/ui/components/TopicPage/TopicPage.tsx
@@ -213,26 +213,6 @@ const TopicPage: React.FC<TopicPageProps> = (props) => {
       active: Boolean(matchPath(routes.tenants.tenant.namespaces.namespace.topics.anyTopicPersistency.topic.schema._.path + '/*', pathname))
     },
     {
-      text: "Unload",
-      type: "regular",
-      position: 'left',
-      testId: "topic-page-unload-button",
-      onClick: () =>
-          modals.push({
-            id: "unload-topic",
-            title: `Unload Topic`,
-            content: (
-                <UnloadTopicDialog
-                    tenant={props.tenant}
-                    namespace={props.namespace}
-                    topic={props.topic}
-                    topicPersistency={props.topicPersistency}
-                />
-            ),
-            styleMode: "no-content-padding",
-          }),
-    },
-    {
       text: "Delete",
       type: "danger",
       position: 'left',

--- a/ui/components/TopicPage/TopicPage.tsx
+++ b/ui/components/TopicPage/TopicPage.tsx
@@ -26,6 +26,7 @@ import useSwr from 'swr';
 import { swrKeys } from "../swrKeys";
 import CreateSubscription from "./Subscriptions/CreateSubscription/CreateSubscription";
 import ExpireAllSubscriptions from "./Subscriptions/ExpireAllMessages/ExpireAllSubscriptions";
+import UnloadTopicDialog from "./UnloadTopicDialog/UnloadTopicDialog";
 
 export type TopicPageView =
   | { type: "consumer-session", managedConsumerSessionId?: string }
@@ -210,6 +211,26 @@ const TopicPage: React.FC<TopicPageProps> = (props) => {
       type: "regular",
       position: 'left',
       active: Boolean(matchPath(routes.tenants.tenant.namespaces.namespace.topics.anyTopicPersistency.topic.schema._.path + '/*', pathname))
+    },
+    {
+      text: "Unload",
+      type: "regular",
+      position: 'left',
+      testId: "topic-page-unload-button",
+      onClick: () =>
+          modals.push({
+            id: "unload-topic",
+            title: `Unload Topic`,
+            content: (
+                <UnloadTopicDialog
+                    tenant={props.tenant}
+                    namespace={props.namespace}
+                    topic={props.topic}
+                    topicPersistency={props.topicPersistency}
+                />
+            ),
+            styleMode: "no-content-padding",
+          }),
     },
     {
       text: "Delete",

--- a/ui/components/TopicPage/UnloadTopicDialog/UnloadTopicDialog.tsx
+++ b/ui/components/TopicPage/UnloadTopicDialog/UnloadTopicDialog.tsx
@@ -32,7 +32,7 @@ const UnloadTopicDialog: React.FC<UnloadTopicDialogProps> = (props) => {
           notifyError(`Unable to unload topic: ${res.getStatus()?.getMessage()}`);
           return;
         }
-        notifySuccess(`${props.topicPersistency === 'persistent' ? 'Persistent' : 'Non-persistent'} topic ${topicFqn} has been successfully unload.`);
+        notifySuccess(`${props.topicPersistency === 'persistent' ? 'Persistent' : 'Non-persistent'} topic ${topicFqn} has been successfully unloaded.`);
 
         modals.pop()
       } catch (err) {

--- a/ui/components/TopicPage/UnloadTopicDialog/UnloadTopicDialog.tsx
+++ b/ui/components/TopicPage/UnloadTopicDialog/UnloadTopicDialog.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { PulsarTopicPersistency } from "../../pulsar/pulsar-resources";
+import ConfirmationDialog from "../../ui/ConfirmationDialog/ConfirmationDialog";
+import * as Modals from '../../app/contexts/Modals/Modals';
+import * as GrpcClient from "../../app/contexts/GrpcClient/GrpcClient";
+import * as Notifications from "../../app/contexts/Notifications";
+import { UnloadTopicRequest } from "../../../grpc-web/tools/teal/pulsar/ui/topic/v1/topic_pb";
+import { Code } from "../../../grpc-web/google/rpc/code_pb";
+
+export type UnloadTopicDialogProps = {
+    tenant: string,
+    namespace: string,
+    topic: string,
+    topicPersistency: PulsarTopicPersistency,
+};
+
+const UnloadTopicDialog: React.FC<UnloadTopicDialogProps> = (props) => {
+  const modals = Modals.useContext();
+  const topicFqn = `${props.topicPersistency}://${props.tenant}/${props.namespace}/${props.topic}`;
+  const { topicServiceClient } = GrpcClient.useContext();
+  const { notifyError, notifySuccess } = Notifications.useContext();
+
+    const unloadTopic = async () => {
+      try {
+        const req = new UnloadTopicRequest()
+
+        req.setTopicName(topicFqn)
+
+        const res = await topicServiceClient.unloadTopic(req, {})
+        if (res.getStatus()?.getCode() !== Code.OK) {
+          notifyError(`Unable to unload topic: ${res.getStatus()?.getMessage()}`);
+          return;
+        }
+        notifySuccess(`${props.topicPersistency === 'persistent' ? 'Persistent' : 'Non-persistent'} topic ${topicFqn} has been successfully unload.`);
+
+        modals.pop()
+      } catch (err) {
+        notifyError(`Unable to unload topic: ${topicFqn}. ${err}`)
+      }
+    }
+
+  return (
+    <ConfirmationDialog
+      content={
+        <div>
+          <div>This action <strong>cannot</strong> be undone.</div>
+          <br />
+          <div>It will unload the <strong>{props.topic}</strong> topic. This will cause temporary unavailability and trigger client reconnections during the ownership transfer.</div>
+        </div>
+      }
+      onConfirm={unloadTopic}
+      onCancel={modals.pop}
+      guard={topicFqn}
+      type='danger'
+    />
+  );
+}
+
+export default UnloadTopicDialog


### PR DESCRIPTION
# Context

This PR introduces the ability to unload topics through the. UI

# Changes

- Added new "Unload" button to the Topic Overview tab (positioned after the Expire Messages button)

<img width="327" height="160" alt="image" src="https://github.com/user-attachments/assets/c178f5c0-f7f7-4c84-9097-b95963a343ab" />

- Created new UnloadTopicDialog to confirm the unload action

<img width="541" height="357" alt="image" src="https://github.com/user-attachments/assets/dbb5b46b-8eba-4868-a82c-cf7aa3c15a3e" />

 