### PR TITLE
Fix defaultPulsarAuth to support AuthParamsStringCredentials (basic / custom plugin auth)

### DIFF
--- a/server/src/main/scala/pulsar_auth/PulsarAuth.scala
+++ b/server/src/main/scala/pulsar_auth/PulsarAuth.scala
@@ -126,6 +126,7 @@ def getDefaultCredentialsFromConfig: Map[CredentialsName, Credentials] =
         case Some(jsonValue: String) =>
             decode[OAuth2Credentials](jsonValue)
                 .orElse(decode[JwtCredentials](jsonValue))
+                .orElse(decode[AuthParamsStringCredentials](jsonValue))
                 .getOrElse(EmptyCredentials(`type` = "empty"))
         case _ => EmptyCredentials(`type` = "empty")
 


### PR DESCRIPTION
## Summary

`getDefaultCredentialsFromConfig` in `PulsarAuth.scala` only attempted to decode
`config.defaultPulsarAuth` (a.k.a. `DEKAF_DEFAULT_PULSAR_AUTH`) as
`OAuth2Credentials` or `JwtCredentials`, falling through to `EmptyCredentials`
in all other cases. `AuthParamsStringCredentials` — used for Pulsar basic auth
and any custom auth plugin — was never tried.

The result: when a deployment provides

```json
{
  "type": "authParamsString",
  "authPluginClassName": "org.apache.pulsar.client.impl.auth.AuthenticationBasic",
  "authParams": "{\"userId\":\"admin\",\"password\":\"...\"}"
}
```

via `DEKAF_DEFAULT_PULSAR_AUTH`, Dekaf silently parses it as `EmptyCredentials`,
builds a `PulsarAdmin` client with no authentication, and every admin REST call
returns 401 (e.g. `Unable to get runtime configurations: HTTP 401`).

The cookie-path decoder (`credentialsDecoder` at `PulsarAuth.scala:103-114`)
already handles `AuthParamsStringCredentials` correctly, which is why setting
the credential manually via the Dekaf UI works around the bug.

The existing behaviour is also inconsistent with
`docs/configuration-reference.md`, which lists
[`AuthParamsStringCredentials`](https://github.com/visortelle/dekaf/blob/main/server/src/main/scala/pulsar_auth/PulsarAuth.scala#L48)
as a supported default-auth method.

## Change

Add `AuthParamsStringCredentials` to the `.orElse` chain so it matches the
cookie path's behaviour.

## Test plan

- [ ] Set `DEKAF_DEFAULT_PULSAR_AUTH='{\"type\":\"authParamsString\",\"authPluginClassName\":\"org.apache.pulsar.client.impl.auth.AuthenticationBasic\",\"authParams\":\"{\\\"userId\\\":\\\"admin\\\",\\\"password\\\":\\\"admin\\\"}\"}'`
- [ ] Open the UI in a clean browser session against a Pulsar cluster with basic auth
- [ ] Verify admin pages (broker runtime config, namespaces, etc.) load without
      having to manually configure credentials in the UI
- [ ] Existing JWT / OAuth2 / Empty defaults continue to work