### PR TITLE
fix(ui): make the connectivity issues overlay closable

### DIFF
--- a/e2e/src/test/scala/routes/HealthCheckSpec.scala
+++ b/e2e/src/test/scala/routes/HealthCheckSpec.scala
@@ -23,3 +23,23 @@ class HealthCheckSpec extends DekafSuite:
     page.unroute(healthCheckUrl)
     assertThat(page.getByTestId("health-overlay")).hasCount(0, new LocatorAssertions.HasCountOptions().setTimeout(20000))
   }
+
+  test("NAV-15: the health overlay can be dismissed while connectivity is still down") {
+    page.navigate("/overview")
+
+    page.route(healthCheckUrl, route => route.abort())
+    assertThat(page.getByTestId("health-overlay")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(20000))
+
+    // The overlay used to have no way out, which made the UI unusable - in particular it
+    // covered the credentials button, so a cluster that needs auth couldn't be authenticated
+    // from the UI at all. See #353.
+    page.getByTestId("health-overlay").press("Escape")
+    assertThat(page.getByTestId("health-overlay")).hasCount(0, new LocatorAssertions.HasCountOptions().setTimeout(10000))
+
+    // Connectivity is still down here: the next poll must not bring the overlay back.
+    page.waitForTimeout(8000)
+    assertThat(page.getByTestId("health-overlay")).hasCount(0)
+
+    // The UI underneath stays usable - the credentials button is reachable again.
+    assertThat(page.getByTestId("credentials-button")).isVisible()
+  }

--- a/ui/components/app/contexts/HealthCheckContext/HealthCheckContext.tsx
+++ b/ui/components/app/contexts/HealthCheckContext/HealthCheckContext.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import * as GrpcClient from '../GrpcClient/GrpcClient';
 import useSWR from 'swr';
 import { swrKeys } from '../../../swrKeys';
@@ -6,7 +6,7 @@ import * as pb from '../../../../grpc-web/tools/teal/pulsar/ui/brokers/v1/broker
 import { Code } from '../../../../grpc-web/google/rpc/code_pb';
 import { createPortal } from 'react-dom';
 import HealthCheck from '../../../InstancePage/Overview/HealthCheck/HealthCheck';
-import { H3 } from '../../../ui/H/H';
+import { ModalElement } from '../Modals/Modals';
 
 type Status = 'unknown' | 'ok' | 'failed';
 type HealthCheckResult = {
@@ -37,6 +37,7 @@ export const DefaultProvider: React.FC<DefaultProviderProps> = (props) => {
   const { brokersServiceClient } = GrpcClient.useContext();
   const [result, setResult] = useState<HealthCheckResult>(defaultValue.healthCheckResult);
   const [brokerVersion, setBrokerVersion] = useState<Value['brokerVersion']>();
+  const [isDismissed, setIsDismissed] = useState(false);
   const lastChecked = React.useRef<number>(0);
 
   useSWR(
@@ -86,43 +87,45 @@ export const DefaultProvider: React.FC<DefaultProviderProps> = (props) => {
     getBrokerVersion();
   }, []);
 
-  const style: CSSProperties = {
-    width: '100vw',
-    height: '100vh',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: '48rem',
-    zIndex: 1000,
-    backgroundColor: 'rgba(0, 0, 0, 0.85)',
-    position: 'fixed',
-    top: 0,
-    left: 0
-  };
+  const isConnectionFailed = result.uiServerConnection === 'failed' || result.brokerConnection === 'failed';
 
-  const isShowOverlay = result.uiServerConnection === 'failed' || result.brokerConnection === 'failed';
+  // Re-arm the overlay once the connection is restored, so that a new outage is
+  // reported again even if the user dismissed the previous one.
+  useEffect(() => {
+    if (!isConnectionFailed) {
+      setIsDismissed(false);
+    }
+  }, [isConnectionFailed]);
+
+  const isShowOverlay = isConnectionFailed && !isDismissed;
   const overlay = isShowOverlay ? createPortal(
-    <div style={style} data-testid="health-overlay">
-      <div style={{ background: '#fff', borderRadius: '12rem', padding: '24rem 48rem', display: 'flex', flexDirection: 'column', gap: '12rem' }}>
-        <div>
-          <H3>
-            There are connectivity issues
-          </H3>
-
-          <ul>
-            <li>
-              If the problem persists, contact your administrator.
-            </li>
-            <li>
-              <a target="_blank" href='https://github.com/visortelle/dekaf/issues'>🛟 Get community support</a> if you are an administrator and not sure how to fix the problem.
-            </li>
-          </ul>
-        </div>
-        <HealthCheck />
-        <div><strong>Last checked at:</strong> {new Date(lastChecked.current).toLocaleTimeString()}</div>
-      </div>
-    </div>,
+    <ModalElement
+      entry={{
+        id: 'health-check',
+        testId: 'health-overlay',
+        title: 'There are connectivity issues',
+        content: (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '12rem' }}>
+            <ul>
+              <li>
+                If your Pulsar cluster requires authentication, close this dialog and set your
+                credentials using the 🔑 button in the navigation sidebar on the left.
+              </li>
+              <li>
+                If the problem persists, contact your administrator.
+              </li>
+              <li>
+                <a target="_blank" href='https://github.com/visortelle/dekaf/issues'>🛟 Get community support</a> if you are an administrator and not sure how to fix the problem.
+              </li>
+            </ul>
+            <HealthCheck />
+            <div><strong>Last checked at:</strong> {new Date(lastChecked.current).toLocaleTimeString()}</div>
+          </div>
+        )
+      }}
+      isVisible
+      onClose={() => setIsDismissed(true)}
+    />,
     document.body
   ) : null;
 

--- a/ui/components/app/contexts/Modals/Modals.tsx
+++ b/ui/components/app/contexts/Modals/Modals.tsx
@@ -16,6 +16,8 @@ export type ModalStackEntry = {
   content: ReactNode,
   isNotCloseable?: boolean,
   styleMode?: 'no-content-padding',
+  /** Overrides the default "modal" test id, for dialogs tests need to tell apart. */
+  testId?: string,
 }
 
 export type ModalStack = ModalStackEntry[];
@@ -83,7 +85,10 @@ type ModalElementProps = {
   onClose: () => void;
 }
 
-const ModalElement: React.FC<ModalElementProps> = (props) => {
+/** The presentational part of a modal: backdrop, card, title bar with the close
+  * icon, and Esc handling. Exported so overlays that live above this provider in
+  * the tree (e.g. the health check overlay) can render the same dialog. */
+export const ModalElement: React.FC<ModalElementProps> = (props) => {
   const isVisible = props.isVisible;
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -106,7 +111,7 @@ const ModalElement: React.FC<ModalElementProps> = (props) => {
       exit={{ opacity: 0, scale: 0.5 }}
       transition={{ duration: 0.25, ease: 'easeInOut', delay: 0.1 }}
       tabIndex={0}
-      data-testid="modal"
+      data-testid={props.entry.testId ?? "modal"}
       onKeyDown={(e) => {
         if (!props.entry.isNotCloseable && e.key === 'Escape') {
           props.onClose();


### PR DESCRIPTION
## Problem

When Dekaf can't reach the Pulsar broker, it shows a full-screen "There are
connectivity issues" overlay that cannot be dismissed — no close button, no Esc,
no click-outside.

That is especially painful when the cluster requires authentication and
`DEKAF_DEFAULT_PULSAR_AUTH` is not set: the health check fails, the overlay
appears, and it covers the credentials button — the very control needed to fix
the connection. As reported in #352, the only workaround was to delete the
overlay via browser devtools.

## What changed

- The overlay now reuses `ModalElement` from `Modals.tsx` — same backdrop, card,
  title bar with the close icon, and Esc handling as every other dialog. The
  component was already presentational; it just wasn't exported.
- The overlay is shown again when the connection drops after having been
  restored, so a new outage is still reported.
- Added a hint about setting Pulsar credentials via the 🔑 button in the
  navigation sidebar, so the dialog says what to do.
- `ModalStackEntry` gained an optional `testId` (defaults to `"modal"`) so the
  overlay keeps the `health-overlay` test id introduced in #351.

The credentials editor can't be opened from the overlay directly, because
`HealthCheckContext` sits above `Modals.DefaultProvider` in the tree — hence the
textual hint.

## Test plan

Added `NAV-11` to `e2e/src/test/scala/routes/HealthCheckSpec.scala`: it aborts the
health check poll, waits for the overlay, dismisses it with Esc, then waits longer
than the 5s poll interval to assert it does not come back while connectivity is
still down, and that the credentials button is reachable again.

Both `NAV-10` (existing) and `NAV-11` pass; `NAV-11` fails without this change.

Fixes #353