### PR TITLE
fix: serve an origin-relative base href

### DIFF
--- a/e2e/src/test/scala/routes/BasePathSpec.scala
+++ b/e2e/src/test/scala/routes/BasePathSpec.scala
@@ -1,0 +1,35 @@
+package routes
+
+import harness.{Config, DekafSuite}
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import com.microsoft.playwright.assertions.LocatorAssertions
+
+import scala.collection.mutable.ListBuffer
+
+/** NAV-16 - the UI must work on whatever host it is actually reached at, not only on the one
+  * configured as DEKAF_PUBLIC_BASE_URL. The page used to carry an absolute <base href> built
+  * from that setting; browsers resolve history.pushState() URLs against the document base URL,
+  * so react-router pushed a URL on a foreign origin, which throws a SecurityError while the app
+  * mounts and leaves a blank page. See #349. */
+class BasePathSpec extends DekafSuite:
+
+  test("NAV-16: the UI loads when opened on a host other than the configured public base URL") {
+    // Same server, different origin as far as the browser is concerned.
+    val otherHostUrl = Config.baseUrl.replace("localhost", "127.0.0.1")
+    assert(otherHostUrl != Config.baseUrl, s"expected a localhost-based DEKAF_BASE_URL, got ${Config.baseUrl}")
+
+    val pageErrors = ListBuffer[String]()
+    page.onPageError(err => pageErrors.synchronized(pageErrors += err))
+
+    // Deliberately the root: landing there makes react-router redirect to /overview, and it is
+    // that history call which used to throw. Opening /overview directly never redirects, so it
+    // would not reproduce the bug.
+    page.navigate(s"${otherHostUrl.stripSuffix("/")}/")
+
+    // A blank page is what the bug looked like, so assert real UI is rendered.
+    assertThat(page.getByText("Pulsar Instance")).isVisible(new LocatorAssertions.IsVisibleOptions().setTimeout(30000))
+
+    val securityErrors = pageErrors.synchronized(pageErrors.toList)
+      .filter(e => e.contains("insecure") || e.contains("SecurityError"))
+    assert(securityErrors.isEmpty, s"unexpected security errors: $securityErrors")
+  }

--- a/server/src/main/resources/ui/index.ftl
+++ b/server/src/main/resources/ui/index.ftl
@@ -2,7 +2,9 @@
 <html lang="en">
 
 <head>
-  <base href="${publicBaseUrl}/" />
+  <#-- Origin-relative on purpose. An absolute base href breaks the UI when Dekaf is
+       opened on a host other than DEKAF_PUBLIC_BASE_URL. See #349. -->
+  <base href="${basePath}" />
 
   <meta charset="UTF-8"/>
   <meta name="viewport"
@@ -27,6 +29,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     const config = {
       publicBaseUrl: '${publicBaseUrl}',
+      basePath: '${basePath}',
       pulsarName: '${pulsarName}',
       pulsarColor: '${pulsarColor}',
       pulsarBrokerUrl: '${pulsarBrokerUrl}',

--- a/server/src/main/scala/server/http/HttpServer.scala
+++ b/server/src/main/scala/server/http/HttpServer.scala
@@ -26,6 +26,18 @@ import java.text.MessageFormat
 object HttpServer:
     private val isBinaryBuild = buildinfo.ExtraBuildInfo.isBinaryBuild
 
+    /** The path part of the public base URL, always starting and ending with a slash.
+      *
+      * The UI uses it as the HTML base href. It has to stay origin-relative: an absolute
+      * base href makes the browser resolve history.pushState URLs against a different
+      * origin whenever Dekaf is opened on another host than the configured public base
+      * URL, which fails with a SecurityError and leaves the user with a blank page.
+      */
+    def basePathOf(publicBaseUrl: String): String =
+        val path = scala.util.Try(java.net.URI(publicBaseUrl).getPath).toOption.filter(_ != null).getOrElse("")
+        val trimmed = path.stripPrefix("/").stripSuffix("/")
+        if trimmed.isEmpty then "/" else s"/$trimmed/"
+
     def createApp(appConfig: Config): Javalin =
         Javalin
             .create { config =>
@@ -62,6 +74,7 @@ object HttpServer:
                     ctx => {
                         val model = Map(
                             "publicBaseUrl" -> appConfig.publicBaseUrl.get,
+                            "basePath" -> basePathOf(appConfig.publicBaseUrl.get),
                             "buildInfo" -> buildinfo.BuildInfo.toMap.asJava,
                             "pulsarBrokerUrl" -> appConfig.pulsarBrokerUrl.get,
                             "pulsarWebUrl" -> appConfig.pulsarWebUrl.get,

--- a/ui/components/app/app.tsx
+++ b/ui/components/app/app.tsx
@@ -47,12 +47,13 @@ const _App: React.FC<AppProps> = (props) => {
         revalidateIfStale: true,
       }}
     >
-      <GrpcClient.DefaultProvider grpcWebUrl={`${props.config.publicBaseUrl.replace(/\/$/, "")}/api`}>
+      {/* Built from the current origin on purpose - see the basePath docs in AppContext. */}
+      <GrpcClient.DefaultProvider grpcWebUrl={`${window.location.origin}${props.config.basePath}api`}>
         <HealthCheckContext.DefaultProvider>
           <Notifications.DefaultProvider>
             <BrokerConfig.DefaultProvider>
               <HelmetProvider>
-                <Router basename={new URL(props.config.publicBaseUrl).pathname} />
+                <Router basename={props.config.basePath} />
               </HelmetProvider>
             </BrokerConfig.DefaultProvider>
           </Notifications.DefaultProvider>

--- a/ui/components/app/contexts/AppContext.tsx
+++ b/ui/components/app/contexts/AppContext.tsx
@@ -9,6 +9,12 @@ type BuildInfo = {
 
 export type Config = {
   publicBaseUrl: string,
+  /**
+   * The path part of publicBaseUrl, starting and ending with a slash, e.g. "/" or "/dekaf/".
+   * Use it instead of publicBaseUrl to build URLs the browser has to request, so that they
+   * stay on the origin the UI is actually served from. See #349.
+   */
+  basePath: string,
   pulsarName: string,
   pulsarColor: string,
   pulsarBrokerUrl: string,
@@ -33,6 +39,7 @@ export type Value = {
 const defaultValue: Value = {
   config: {
     publicBaseUrl: '',
+    basePath: '/',
     pulsarName: '',
     pulsarColor: '',
     pulsarBrokerUrl: '',

--- a/ui/components/app/pulsar-auth/Editor/CredentialsEditor/CredentialsEditor.tsx
+++ b/ui/components/app/pulsar-auth/Editor/CredentialsEditor/CredentialsEditor.tsx
@@ -90,7 +90,7 @@ const CredentialsEditor: React.FC<CredentialsEditorProps> = (props) => {
           disabled={credentialsName.length === 0}
           text='Save'
           onClick={async () => {
-            await fetch(`${config.publicBaseUrl}/pulsar-auth/add/${encodeURIComponent(credentialsName)}`, {
+            await fetch(`${config.basePath}pulsar-auth/add/${encodeURIComponent(credentialsName)}`, {
               method: 'POST',
               body: JSON.stringify(credentials),
               headers: {

--- a/ui/components/app/pulsar-auth/Editor/Editor.tsx
+++ b/ui/components/app/pulsar-auth/Editor/Editor.tsx
@@ -96,7 +96,7 @@ const Editor: React.FC<EditorProps> = (props) => {
                           testId="credentials-set-current"
                           type='regular'
                           onClick={async () => {
-                            await fetch(`${config.publicBaseUrl}/pulsar-auth/use/${encodeURIComponent(item.name)}`, { method: 'POST' })
+                            await fetch(`${config.basePath}pulsar-auth/use/${encodeURIComponent(item.name)}`, { method: 'POST' })
                               .catch((err) => notifyError(`Unable to set current credentials: ${err}`));
                             await mutate(swrKeys.pulsar.auth.credentials._());
                             await mutate(swrKeys.pulsar.auth.credentials.current._());
@@ -107,7 +107,7 @@ const Editor: React.FC<EditorProps> = (props) => {
                           testId="credentials-delete"
                           type='danger'
                           onClick={async () => {
-                            await fetch(`${config.publicBaseUrl}/pulsar-auth/delete/${encodeURIComponent(item.name)}`, { method: 'POST' })
+                            await fetch(`${config.basePath}pulsar-auth/delete/${encodeURIComponent(item.name)}`, { method: 'POST' })
                               .catch((err) => notifyError(`Unable to delete credentials: ${err}`));
                             await mutate(swrKeys.pulsar.auth.credentials._());
                             await mutate(swrKeys.pulsar.auth.credentials.current._());


### PR DESCRIPTION
## Problem

Dekaf renders a blank page when opened on a host other than the one in
`DEKAF_PUBLIC_BASE_URL` — e.g., a container published as `127.0.0.1:8091` but
reached via `localhost:8091`.

The page carried an absolute `<base href>` built from that setting, and the
browser resolves everything relative against it. Two failure modes, depending on
whether that host is reachable from the client:

- **Not reachable** — `<script src="ui/static/dist/entrypoint.js">` resolves to
  the user's own machine: `Uncaught ReferenceError: pulsarUiEntrypoint is not defined`.
- **Reachable but a different origin** (the case in #349) — assets load, then
  react-router calls `history.pushState()` with a foreign-origin URL, which
  browsers forbid: `Uncaught DOMException: The operation is insecure.`

Either way, the app dies while mounting, with no hint about what to fix.

## What changed

- Serve only the **path** part of `DEKAF_PUBLIC_BASE_URL` as the base href (`/`,
  or `/dekaf/` behind a reverse-proxy prefix). A path always resolves against the
  origin the page came from, so no mismatch is possible.
- Build the gRPC-web and pulsar-auth URLs from the current origin too (new
  `basePath` field on the UI config) — otherwise the app would render but fail
  every request with CORS.

Reverse-proxy prefixes still work: `DEKAF_PUBLIC_BASE_URL=http://localhost:8090/demo`
serves `<base href="/demo/" />`.

## Test plan

Added `NAV-16` (`e2e/src/test/scala/routes/BasePathSpec.scala`): opens Dekaf on
`127.0.0.1` while the server is configured for `localhost`, asserts the UI renders
and that no `SecurityError` is raised. It navigates to `/` on purpose — the root
redirect is what triggers the failing history call; going straight to `/overview`
passes even with the bug.

Verified it fails without the fix. Also re-ran `OverviewSmokeSpec`,
`NavigationSpec`, `CredentialsSpec`, `HealthCheckSpec` — 10 tests, all green.

Fixes #349