### PR TITLE
fix(ui): apply projections picked from the library

### DIFF
--- a/e2e/src/test/scala/features/consumersession/CsProjectionLibrarySpec.scala
+++ b/e2e/src/test/scala/features/consumersession/CsProjectionLibrarySpec.scala
@@ -1,0 +1,59 @@
+package features.consumersession
+
+import harness.DekafSuite
+import features.library.{LibraryBrowser, LibrarySaveDialog}
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import com.microsoft.playwright.assertions.LocatorAssertions
+
+/** CS-33 - saving a projection to the Library and applying it to a *different* projection.
+  * Picking used to do nothing visible: the browse dialog stayed open, and the projection list
+  * looked the replaced item up by the id of the newly picked projection, which never matched
+  * any row, so the pick was dropped. See #339. */
+class CsProjectionLibrarySpec extends DekafSuite:
+  private val visible = new LocatorAssertions.IsVisibleOptions().setTimeout(20000)
+  private val gone    = new LocatorAssertions.HasCountOptions().setTimeout(20000)
+  private val applied = new LocatorAssertions.HasValueOptions().setTimeout(20000)
+
+  test("CS-33: a projection picked from the library replaces the projection being edited") {
+    val (t, ns, topic) = fixtures.freshTopicParts()
+    val cs = ConsumerSessionPage(page)
+    cs.openForTopic(t, ns, topic)
+    cs.revealAdvanced()
+
+    val savedLabel  = s"saved-${System.currentTimeMillis}"
+    val libraryItem = s"projection-${System.currentTimeMillis}"
+
+    // Each projection has its own library panel, as do the projection list and a
+    // projection's target - hence addressing panels by the item type they manage.
+    def projectionPanel(i: Int) = cs.sessionProjections.getByTestId("lib-panel-value-projection").nth(i)
+
+    // A projection saved to the library...
+    cs.addProjection()
+    cs.projectionLabel.nth(0).fill(savedLabel)
+    projectionPanel(0).hover()
+    projectionPanel(0).getByTestId("lib-save").click()
+    val saveDialog = LibrarySaveDialog(page)
+    saveDialog.saveButton.click()          // "Create" with an empty name opens the Set-Name dialog
+    saveDialog.nameInput.fill(libraryItem)
+    saveDialog.nameConfirm.click()
+    assertThat(saveDialog.saveButton).hasCount(0, gone)
+
+    // ...and applied to a second, unrelated projection. It carries a different id, which is
+    // precisely what the old id-based lookup could not handle.
+    cs.addProjection()
+    val secondLabel = s"second-${System.currentTimeMillis}"
+    cs.projectionLabel.nth(1).fill(secondLabel)
+
+    projectionPanel(1).hover()
+    projectionPanel(1).getByTestId("lib-item-count").click()
+    val browser = LibraryBrowser(page)
+    assertThat(browser.selectButton).isVisible(visible)
+    browser.filter(libraryItem)
+    browser.result(libraryItem).click()
+    browser.selectButton.click()
+
+    // The dialog used to stay open, and the picked projection used to be dropped.
+    assertThat(browser.selectButton).hasCount(0, gone)
+    assertThat(cs.projectionLabel.nth(1)).hasValue(savedLabel, applied)
+    assertThat(cs.projectionLabel.nth(0)).hasValue(savedLabel, applied)
+  }

--- a/ui/components/ui/ConsumerSession/value-projections/ValueProjectionListInput/ValueProjectionListInput.tsx
+++ b/ui/components/ui/ConsumerSession/value-projections/ValueProjectionListInput/ValueProjectionListInput.tsx
@@ -90,13 +90,15 @@ const ValueProjectionListInput: React.FC<ValueProjectionListInputProps> = (props
 
       <ListInput<ManagedValueProjectionValOrRef>
         getId={(v) => v.val?.metadata.id || ''}
-        renderItem={(v) => {
+        renderItem={(v, i) => {
           return (
             <ValueProjectionInput
               value={v}
-              onChange={(v) => {
+              onChange={(updatedProjection) => {
+                // Match by position. Matching by id doesn't work when the projection is
+                // replaced by one picked from the library, which carries a different id.
                 const newProjections = itemSpec.projections
-                  .map(projection => projection.val?.metadata.id === v.val?.metadata.id ? v : projection);
+                  .map((projection, projectionIndex) => projectionIndex === i ? updatedProjection : projection);
                 onSpecChange({ ...itemSpec, projections: newProjections });
               }}
               libraryContext={props.libraryContext}

--- a/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserButtons/LibraryBrowserButtons.tsx
+++ b/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserButtons/LibraryBrowserButtons.tsx
@@ -30,6 +30,7 @@ const LibraryBrowserButtons: React.FC<LibraryBrowserButtonsProps> = (props) => {
           item={props.value}
           libraryContext={props.libraryContext}
           onSaved={props.onSave}
+          testId="lib-save"
         />
       )}
 

--- a/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserButtons/PickLibraryItemButton/PickLibraryItemButton.tsx
+++ b/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserButtons/PickLibraryItemButton/PickLibraryItemButton.tsx
@@ -82,6 +82,7 @@ const LibraryBrowserPickButton: React.FC<LibraryBrowserPickButtonProps> = (props
                 itemType={props.itemType}
                 onSelected={(libraryItem) => {
                   props.onPick(libraryItem.spec);
+                  modals.pop();
                 }}
                 onCanceled={modals.pop}
                 libraryContext={props.libraryContext}

--- a/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserPanel.tsx
+++ b/ui/components/ui/LibraryBrowser/LibraryBrowserPanel/LibraryBrowserPanel.tsx
@@ -49,7 +49,7 @@ const LibraryBrowserPanel: React.FC<LibraryBrowserPanelProps> = (props) => {
   const availableForContexts = useMemo(() => [resourceMatcherFromContext(props.libraryContext, 'derive-from-context')], [props.libraryContext]);
 
   return (
-    <div className={s.LibraryBrowserPanel} ref={hoverRef}>
+    <div className={s.LibraryBrowserPanel} ref={hoverRef} data-testid={`lib-panel-${props.itemType}`}>
       <div style={{ display: 'inline-flex', position: 'relative' }}>
         <FormLabel
           content={(


### PR DESCRIPTION
## Problem

Picking a saved projection from the Library had no visible effect (#339):

- the browse dialog stayed open after picking, so it looked like nothing happened;
- the projection list looked up the row to replace by the id of the **newly picked**
  projection, which never matched anything — so the pick was silently dropped.

Consumer sessions were unaffected: their library browser lives in the sidebar and
navigates, instead of editing a list in place.

## What changed

- Close the browse dialog after picking, like Cancel already did.
- Replace the projection by position instead of by id.
- Added `lib-panel-<itemType>` and `lib-save` test ids — a projection, the projection
  list and a projection's target each own a library panel, so tests must tell them apart.

## Test plan

Added `CS-33` (`CsProjectionLibrarySpec`): saves a projection to the library, adds a
**second** one and applies the saved projection to it — their ids differ, which is
exactly what the old lookup could not handle. Asserts the dialog closes, the second
projection takes the saved label, and the first is untouched.

Note: an earlier version re-picked the *same* projection and passed even with the bug,
since the ids happened to match. Verified the current test fails without the fix.

`LibrarySelectSpec`, `LibraryBrowseSpec`, `LibraryCrudSpec` — 14 tests, all green.

Fixes #339